### PR TITLE
Fix slug is not defined notice

### DIFF
--- a/src/GitHub_Plugin_Updater.php
+++ b/src/GitHub_Plugin_Updater.php
@@ -196,6 +196,7 @@ class GitHub_Plugin_Updater {
 		}
 
 		$obj               = new \stdClass();
+		$obj->slug         = $this->plugin_name;
 		$obj->name         = esc_html( $current['Name'] );
 		$obj->plugin_name  = esc_html( $current['Name'] );
 		$obj->author       = sprintf( '<a href="%1$s" target="_blank">%2$s</a>', esc_url( $this->api_data->author->html_url ), esc_html( $this->api_data->author->login ) );


### PR DESCRIPTION
こんにちは !  これ使ってみてたんですが、プラグインの詳細を開いたときに slug が undefined になってたので、直しました。